### PR TITLE
Add basic Jest setup with ProjectsSection test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,19 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  dir: './',
+})
+
+const customJestConfig = {
+  moduleDirectories: ['node_modules', '<rootDir>/'],
+  testEnvironment: 'jest-environment-jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '^@/(.*)$': '<rootDir>/@/$1',
+    '^portfoliov1/(.*)$': '<rootDir>/src/$1',
+    '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
+  },
+}
+
+module.exports = createJestConfig(customJestConfig)

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/package.json
+++ b/package.json
@@ -1,39 +1,49 @@
 {
-	"name": "portfoliov1",
-	"version": "0.1.0",
-	"private": true,
-	"scripts": {
-		"dev": "next dev",
-		"build": "next build",
-		"start": "next start",
-		"lint": "next lint"
-	},
-	"dependencies": {
-		"@radix-ui/react-dialog": "^1.0.5",
-		"@radix-ui/react-icons": "^1.3.0",
-		"add": "^2.0.6",
-		"badge": "^1.0.3",
-		"class-variance-authority": "^0.7.0",
-		"clsx": "^2.1.0",
-		"framer-motion": "^11.0.12",
-		"lucide-react": "^0.303.0",
-		"next": "14.0.4",
-		"react": "^18",
-		"react-dom": "^18",
-		"react-type-animation": "^3.2.0",
-		"react-typed": "^1.2.0",
-		"shadcn-ui": "^0.5.0",
-		"tailwind-merge": "^2.2.1",
-		"tailwindcss-animate": "^1.0.7"
-	},
-	"devDependencies": {
-		"@iconify/react": "^4.1.1",
-		"@types/node": "^20",
-		"@types/react": "^18",
-		"@types/react-dom": "^18",
-		"autoprefixer": "^10.4.16",
-		"postcss": "^8.4.32",
-		"tailwindcss": "^3.4.0",
-		"typescript": "^5"
-	}
+  "name": "portfoliov1",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-icons": "^1.3.0",
+    "add": "^2.0.6",
+    "badge": "^1.0.3",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "framer-motion": "^11.0.12",
+    "lucide-react": "^0.303.0",
+    "next": "14.0.4",
+    "react": "^18",
+    "react-dom": "^18",
+    "react-type-animation": "^3.2.0",
+    "react-typed": "^1.2.0",
+    "shadcn-ui": "^0.5.0",
+    "tailwind-merge": "^2.2.1",
+    "tailwindcss-animate": "^1.0.7"
+  },
+  "devDependencies": {
+    "@iconify/react": "^4.1.1",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "autoprefixer": "^10.4.16",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.0-beta.3",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.4.0",
+    "ts-jest": "^29.3.4",
+    "typescript": "^5"
+  }
 }

--- a/src/components/__tests__/ProjectsSection.test.tsx
+++ b/src/components/__tests__/ProjectsSection.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import ProjectsSection from '../ProjectsSection'
+
+describe('ProjectsSection', () => {
+  it('renders all project titles', () => {
+    render(<ProjectsSection />)
+    const titles = [
+      'Confention',
+      'Samklaang',
+      'Helmdall',
+      'Shopydoo',
+      'Jarnkit',
+      'ResearchBook'
+    ]
+    titles.forEach(title => {
+      expect(screen.getByText(title)).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- configure Jest for Next.js
- add test utils setup
- add ProjectsSection component test
- expose `npm test` script

## Testing
- `npm test -- -w=1`

------
https://chatgpt.com/codex/tasks/task_e_68417ff1a9a08329a834fbf2ede59573